### PR TITLE
Restrict default port exposure and require strong Postgres credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,15 @@ Just click and add your AI provider API key.
 git clone https://github.com/bytebot-ai/bytebot.git
 cd bytebot
 
-# Add your AI provider key (choose one)
-echo "ANTHROPIC_API_KEY=sk-ant-..." > docker/.env
-# Or: echo "OPENAI_API_KEY=sk-..." > docker/.env
-# Or: echo "GEMINI_API_KEY=..." > docker/.env
+# Add database credentials and your AI provider key (choose one)
+cat <<'EOF' > docker/.env
+POSTGRES_USER=bytebot
+POSTGRES_PASSWORD=replace-with-strong-password
+POSTGRES_DB=bytebotdb
+ANTHROPIC_API_KEY=sk-ant-...
+# Or: OPENAI_API_KEY=sk-...
+# Or: GEMINI_API_KEY=...
+EOF
 
 docker-compose -f docker/docker-compose.yml up -d
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Sicherheitsüberblick
+
+## Sicherheitsauffälligkeiten
+- Offen exponierte Ports (Agent 9991, Desktop 9990, Postgres 5432, UI 9992) ohne Zugriffsbegrenzung
+- Standard‑ oder schwache Zugangsdaten (z. B. `postgres/postgres`)
+- Fehlende Authentifizierung und CORS‑Beschränkung für Agent‑ und Desktop‑APIs
+- Proxy‑Weiterleitungen zu internen Diensten ohne Authentifizierung
+- Unsichere Container‑Konfiguration (privilegierter Desktop‑Container, `root`‑Nutzer)
+- Verwendung ungeprüfter Paketquellen und `curl`‑Installationen im Dockerfile
+- Bekannte Schwachstellen in Abhängigkeiten (z. B. Next.js)
+
+## Maßnahmenplan
+1. **Netzwerkabschottung**
+   - Externe Portfreigaben minimieren und Dienste nur intern bzw. über VPN/Firewall erreichbar machen.
+   - Starke, individuelle Postgres‑Credentials erzwingen und Port 5432 nur intern freigeben.
+2. **Authentifizierung & Autorisierung**
+   - Für UI, Agent‑API und VNC/WebSocket zwingende Authentifizierung (OAuth2, API‑Keys, JWT) einführen.
+   - CORS auf vertrauenswürdige Domains beschränken.
+3. **Transportverschlüsselung**
+   - TLS für alle HTTP/WS‑Verbindungen mittels Reverse‑Proxy (z. B. Nginx, Traefik) erzwingen.
+4. **Container‑Härtung**
+   - `privileged` entfernen, Container als nicht‑privilegierten Benutzer starten und nur notwendige Capabilities vergeben.
+   - Downloads im Dockerfile versionieren und deren Integrität prüfen.
+5. **Proxy‑Absicherung**
+   - Proxy‑Endpunkte nur für authentifizierte Benutzer freischalten und ggf. zusätzliche ACLs einsetzen.
+6. **Abhängigkeits‑Management**
+   - Regelmäßige Updates und Sicherheits‑Scans (`npm audit`, Image‑Scanning) integrieren.
+7. **Eingabe‑Validierung & Logging**
+   - Globale Validierungspipes aktivieren, sicherheitsrelevante Ereignisse loggen und Rate‑Limiting einsetzen.
+8. **Secret‑Handling**
+   - API‑Keys und Secrets in Secret‑Managern oder verschlüsselten `.env`‑Dateien verwalten.
+9. **Betrieb & Monitoring**
+   - Firewall‑Regeln, IDS/IPS und System‑Updates automatisieren sowie regelmäßige Penetrationstests durchführen.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and provide your own values
+# Strong database credentials
+POSTGRES_USER=bytebot
+POSTGRES_PASSWORD=change-me-please
+POSTGRES_DB=bytebotdb
+
+# Optional AI provider keys
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=

--- a/docker/docker-compose-claude-code.yml
+++ b/docker/docker-compose-claude-code.yml
@@ -13,8 +13,6 @@ services:
     restart: unless-stopped
     hostname: computer
     privileged: true
-    ports:
-      - "9990:9990" # bytebotd service & noVNC
     environment:
       - DISPLAY=:0
     networks:
@@ -24,12 +22,10 @@ services:
     image: postgres:16-alpine
     container_name: bytebot-postgres
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=bytebotdb
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER:-bytebot}
+      - POSTGRES_DB=${POSTGRES_DB:-bytebotdb}
     networks:
       - bytebot-network
     volumes:
@@ -41,10 +37,8 @@ services:
       dockerfile: bytebot-agent-cc/Dockerfile
     container_name: bytebot-agent-cc
     restart: unless-stopped
-    ports:
-      - "9991:9991"
     environment:
-      - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bytebotdb}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-bytebot}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-bytebotdb}}
       - BYTEBOT_DESKTOP_BASE_URL=${BYTEBOT_DESKTOP_BASE_URL:-http://bytebot-desktop:9990}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     depends_on:

--- a/docker/docker-compose.core.yml
+++ b/docker/docker-compose.core.yml
@@ -13,7 +13,5 @@ services:
     restart: unless-stopped
     hostname: computer
     privileged: true
-    ports:
-      - "9990:9990" # bytebotd service & noVNC
     environment:
       - DISPLAY=:0

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -18,8 +18,6 @@ services:
     restart: unless-stopped
     hostname: computer
     privileged: true
-    ports:
-      - "9990:9990" # bytebotd service & noVNC
     environment:
       - DISPLAY=:0
     networks:
@@ -29,12 +27,10 @@ services:
     image: postgres:16-alpine
     container_name: bytebot-postgres
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=bytebotdb
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER:-bytebot}
+      - POSTGRES_DB=${POSTGRES_DB:-bytebotdb}
     networks:
       - bytebot-network
     volumes:

--- a/docker/docker-compose.proxy.yml
+++ b/docker/docker-compose.proxy.yml
@@ -13,8 +13,6 @@ services:
     restart: unless-stopped
     hostname: computer
     privileged: true
-    ports:
-      - "9990:9990" # bytebotd service & noVNC
     environment:
       - DISPLAY=:0
     networks:
@@ -24,12 +22,10 @@ services:
     image: postgres:16-alpine
     container_name: bytebot-postgres
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=bytebotdb
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER:-bytebot}
+      - POSTGRES_DB=${POSTGRES_DB:-bytebotdb}
     networks:
       - bytebot-network
     volumes:
@@ -43,10 +39,8 @@ services:
     image: ghcr.io/bytebot-ai/bytebot-agent:edge
     container_name: bytebot-agent
     restart: unless-stopped
-    ports:
-      - "9991:9991"
     environment:
-      - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bytebotdb}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-bytebot}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-bytebotdb}}
       - BYTEBOT_DESKTOP_BASE_URL=${BYTEBOT_DESKTOP_BASE_URL:-http://bytebot-desktop:9990}
       - BYTEBOT_LLM_PROXY_URL=${BYTEBOT_LLM_PROXY_URL:-http://bytebot-llm-proxy:4000}
     depends_on:
@@ -58,8 +52,6 @@ services:
     build:
       context: ../packages/
       dockerfile: bytebot-llm-proxy/Dockerfile
-    ports:
-      - "4000:4000"
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,6 @@ services:
     restart: unless-stopped
     hostname: computer
     privileged: true
-    ports:
-      - "9990:9990" # bytebotd service & noVNC
     environment:
       - DISPLAY=:0
     networks:
@@ -24,12 +22,10 @@ services:
     image: postgres:16-alpine
     container_name: bytebot-postgres
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=bytebotdb
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER:-bytebot}
+      - POSTGRES_DB=${POSTGRES_DB:-bytebotdb}
     networks:
       - bytebot-network
     volumes:
@@ -43,10 +39,8 @@ services:
     image: ghcr.io/bytebot-ai/bytebot-agent:edge
     container_name: bytebot-agent
     restart: unless-stopped
-    ports:
-      - "9991:9991"
     environment:
-      - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/bytebotdb}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-bytebot}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-bytebotdb}}
       - BYTEBOT_DESKTOP_BASE_URL=${BYTEBOT_DESKTOP_BASE_URL:-http://bytebot-desktop:9990}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/docs/core-concepts/desktop-environment.mdx
+++ b/docs/core-concepts/desktop-environment.mdx
@@ -208,9 +208,7 @@ deploy:
    environment:
      - ALLOWED_DOMAINS=company.com,trusted-site.com
    
-   # Or restrict to local network only
-   ports:
-     - "10.0.0.0/8:9990:9990"
+   # Services are kept internal by default; use VPN or reverse proxy for external access
    ```
 
 ## Troubleshooting

--- a/docs/deployment/litellm.mdx
+++ b/docs/deployment/litellm.mdx
@@ -323,11 +323,12 @@ docker-compose -f docker/docker-compose.yml up -d
 # Run your own LiteLLM instance
 docker run -d \
   --name litellm-external \
-  -p 4000:4000 \
   -v $(pwd)/custom-config.yaml:/app/config.yaml \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
   ghcr.io/berriai/litellm:main \
   --config /app/config.yaml
+# Optional: expose port if accessing outside Docker network
+#  -p 4000:4000 \
 
 # Then start Bytebot with:
 export BYTEBOT_LLM_PROXY_URL=http://localhost:4000

--- a/helm/charts/bytebot-agent/values.yaml
+++ b/helm/charts/bytebot-agent/values.yaml
@@ -56,7 +56,7 @@ apiKeys:
     value: ""  # Only used if useExisting is false
 
 config:
-  databaseUrl: "postgresql://postgres:postgres@bytebot-postgresql:5432/bytebotdb"
+  databaseUrl: "postgresql://bytebot:change-me-please@bytebot-postgresql:5432/bytebotdb"
   bytebotDesktopUrl: "http://bytebot-desktop:9990"
   llmProxyUrl: ""
 
@@ -74,8 +74,8 @@ ingress:
 postgresql:
   enabled: true
   auth:
-    username: postgres
-    password: postgres
+    username: bytebot
+    password: change-me-please # replace with a strong unique password
     database: bytebotdb
   service:
     port: 5432
@@ -88,7 +88,7 @@ externalDatabase:
   host: ""
   port: 5432
   database: bytebotdb
-  username: postgres
-  password: postgres
+  username: bytebot
+  password: change-me-please
   existingSecret: ""
   existingSecretPasswordKey: ""

--- a/helm/charts/postgresql/values.yaml
+++ b/helm/charts/postgresql/values.yaml
@@ -36,8 +36,8 @@ tolerations: []
 affinity: {}
 
 auth:
-  username: postgres
-  password: postgres
+  username: bytebot
+  password: change-me-please # replace with a strong unique password
   database: bytebotdb
 
 config:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,8 +5,8 @@ postgresql:
   enabled: true
   fullnameOverride: "bytebot-postgresql"
   auth:
-    username: postgres
-    password: postgres
+    username: bytebot
+    password: change-me-please # replace with a strong unique password
     database: bytebotdb
   service:
     port: 5432
@@ -49,8 +49,8 @@ bytebot-agent:
     host: "bytebot-postgresql"
     port: 5432
     database: bytebotdb
-    username: postgres
-    password: postgres
+    username: bytebot
+    password: change-me-please # must match postgresql.auth.password
   # Legacy API key configuration (for backward compatibility)
   env:
     ANTHROPIC_API_KEY: ""

--- a/packages/bytebot-agent-cc/.env.example
+++ b/packages/bytebot-agent-cc/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://postgres:postgres@postgres:5432/bytebotdb
+DATABASE_URL=postgresql://bytebot:change-me-please@postgres:5432/bytebotdb
 ANTHROPIC_API_KEY=
 BYTEBOT_DESKTOP_BASE_URL=http://localhost:9990
 BYTEBOT_ANALYTICS_ENDPOINT=

--- a/packages/bytebot-agent/.env.example
+++ b/packages/bytebot-agent/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql://postgres:postgres@postgres:5432/bytebotdb
+DATABASE_URL=postgresql://bytebot:change-me-please@postgres:5432/bytebotdb
 ANTHROPIC_API_KEY=
 BYTEBOT_DESKTOP_BASE_URL=http://localhost:9990
 BYTEBOT_ANALYTICS_ENDPOINT=


### PR DESCRIPTION
## Summary
- remove external port mappings from docker-compose files
- require user-defined Postgres credentials and provide an `.env` example
- document keeping services internal with optional port exposure

## Testing
- `docker-compose -f docker/docker-compose.yml config` *(fails: 'name' does not match any of the regexes: '^x-' )*
- `helm version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc91dd8f8832e82fb835a2b6546db