### PR TITLE
Disable Express X-Powered-By header

### DIFF
--- a/Security.md
+++ b/Security.md
@@ -1,0 +1,9 @@
+# Security
+
+Dieser Maßnahmenplan dokumentiert bekannte Sicherheitsrisiken und deren Status.
+
+## Maßnahmenplan
+
+| Risiko | Maßnahme | Status |
+| --- | --- | --- |
+| Express sendet den Header `X-Powered-By` und verrät die eingesetzte Technologie. | Header im Server deaktivieren, um Informationsoffenlegung zu vermeiden. | ✅ erledigt |

--- a/packages/bytebot-ui/server.ts
+++ b/packages/bytebot-ui/server.ts
@@ -27,6 +27,7 @@ app
     const vncProxy = createProxyServer({ changeOrigin: true, ws: true });
 
     const expressApp = express();
+    expressApp.disable("x-powered-by");
     const server = createServer(expressApp);
 
     // WebSocket proxy for Socket.IO connections to backend


### PR DESCRIPTION
## Summary
- disable Express `X-Powered-By` header to reduce information leakage
- document mitigation in new security plan

## Testing
- `npm run lint --prefix packages/bytebot-ui`


------
https://chatgpt.com/codex/tasks/task_e_68c08b6826f4832e92b44c7d02f76bc7