### PR TITLE
Disable Express X-Powered-By header

### DIFF
--- a/Security.md
+++ b/Security.md
@@ -6,4 +6,4 @@ Dieser Maßnahmenplan dokumentiert bekannte Sicherheitsrisiken und deren Status.
 
 | Risiko | Maßnahme | Status |
 | --- | --- | --- |
-| Express sendet den Header `X-Powered-By` und verrät die eingesetzte Technologie. | Header im Server deaktivieren, um Informationsoffenlegung zu vermeiden. | ✅ erledigt |
+| Express sendet den Header `X-Powered-By` und verrät die eingesetzte Technologie. | Header im Server deaktivieren, um Informationsoffenlegung zu vermeiden. | ✅ erledigt (alle Dienste) |

--- a/packages/bytebot-agent-cc/src/main.ts
+++ b/packages/bytebot-agent-cc/src/main.ts
@@ -14,6 +14,9 @@ async function bootstrap() {
   try {
     const app = await NestFactory.create(AppModule);
 
+    // Disable Express "X-Powered-By" header to avoid information disclosure
+    app.getHttpAdapter().getInstance().disable('x-powered-by');
+
     // Configure body parser with increased payload size limit (50MB)
     app.use(json({ limit: '50mb' }));
     app.use(urlencoded({ limit: '50mb', extended: true }));

--- a/packages/bytebot-agent/src/main.ts
+++ b/packages/bytebot-agent/src/main.ts
@@ -14,6 +14,9 @@ async function bootstrap() {
   try {
     const app = await NestFactory.create(AppModule);
 
+    // Disable Express "X-Powered-By" header to avoid information disclosure
+    app.getHttpAdapter().getInstance().disable('x-powered-by');
+
     // Configure body parser with increased payload size limit (50MB)
     app.use(json({ limit: '50mb' }));
     app.use(urlencoded({ limit: '50mb', extended: true }));

--- a/packages/bytebotd/src/main.ts
+++ b/packages/bytebotd/src/main.ts
@@ -6,6 +6,8 @@ import { json, urlencoded } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  // Disable Express "X-Powered-By" header to avoid information disclosure
+  app.getHttpAdapter().getInstance().disable('x-powered-by');
 
   // Configure body parser with increased payload size limit (50MB)
   app.use(json({ limit: '50mb' }));


### PR DESCRIPTION
## Summary
- disable Express `X-Powered-By` header across NestJS services
- document mitigation in security plan

## Testing
- `npm test -- --passWithNoTests` (packages/bytebotd)
- `npm test -- --passWithNoTests` (packages/bytebot-agent)
- `npm test -- --passWithNoTests` (packages/bytebot-agent-cc)


------
https://chatgpt.com/codex/tasks/task_e_68c08d523ff8832e83777ab06eb30fbb